### PR TITLE
home-manager: allow parallel install of XCursor

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -9,11 +9,11 @@ self: {
     home.file = {
       "phinger-cursors-light" = {
         source = "${self.packages.${pkgs.system}.hyprcursor-phinger}/cursors/theme_phinger-cursors-light";
-        target = ".local/share/icons/phinger-cursors-light";
+        target = ".local/share/icons/phinger-cursors-light-hyprcursor";
       };
       "phinger-cursors-dark" = {
         source = "${self.packages.${pkgs.system}.hyprcursor-phinger}/cursors/theme_phinger-cursors-dark";
-        target = ".local/share/icons/phinger-cursors-dark";
+        target = ".local/share/icons/phinger-cursors-dark-hyprcursor";
       };
     };
   };


### PR DESCRIPTION
#### Problem
I tried installing this alongside the XCursor-Variant from [`nixpkgs.phinger-cursors`](https://search.nixos.org/packages?channel=24.05&show=phinger-cursors&from=0&size=50&sort=relevance&type=packages&query=phinger) but got errors because they try to write to the same directory.

#### Solution
Changed the link targets to avoid conflicts when installing the original XCursor theme as a fallback (since gtk apps don't support hyprcursor).