### PR TITLE
chore: stop using deprecated pkgs.system

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728492678,
-        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
+        "lastModified": 1762977756,
+        "narHash": "sha256-4PqRErxfe+2toFJFgcRKZ0UI9NSIOJa+7RXVtBhy4KE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+        "rev": "c5ae371f1a6a7fd27823bc500d9390b38c05fa55",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,36 +5,32 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
   };
 
-  outputs =
-    {
-      self,
-      nixpkgs,
-    }:
-    let
-      forAllSystems =
-        function:
-        nixpkgs.lib.genAttrs [
-          "aarch64-linux"
-          "x86_64-linux"
-        ] (system: function nixpkgs.legacyPackages.${system});
-    in
-    {
-      devShells = forAllSystems (pkgs: {
-        default = pkgs.mkShell {
-          packages = with pkgs; [
-            hyprcursor
-            xcur2png
-            ripgrep
-            jq
-            bc
-          ];
-        };
-      });
-      packages = forAllSystems (pkgs: {
-        default = self.packages.${pkgs.system}.hyprcursor-phinger;
-        hyprcursor-phinger = pkgs.callPackage ./nix/package.nix { inherit pkgs; };
-      });
-      homeManagerModules.default = self.homeManagerModules.hyprcursor-phinger;
-      homeManagerModules.hyprcursor-phinger = import ./nix/hm-module.nix self;
-    };
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    forAllSystems = function:
+      nixpkgs.lib.genAttrs [
+        "aarch64-linux"
+        "x86_64-linux"
+      ] (system: function nixpkgs.legacyPackages.${system});
+  in {
+    devShells = forAllSystems (pkgs: {
+      default = pkgs.mkShell {
+        packages = with pkgs; [
+          hyprcursor
+          xcur2png
+          ripgrep
+          jq
+          bc
+        ];
+      };
+    });
+    packages = forAllSystems (pkgs: {
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.hyprcursor-phinger;
+      hyprcursor-phinger = pkgs.callPackage ./nix/package.nix {inherit pkgs;};
+    });
+    homeManagerModules.default = self.homeManagerModules.hyprcursor-phinger;
+    homeManagerModules.hyprcursor-phinger = import ./nix/hm-module.nix self;
+  };
 }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -8,11 +8,11 @@ self: {
   config = lib.mkIf config.programs.hyprcursor-phinger.enable {
     home.file = {
       "phinger-cursors-light" = {
-        source = "${self.packages.${pkgs.system}.hyprcursor-phinger}/share/icons/theme_phinger-cursors-light";
+        source = "${self.packages.${pkgs.stdenv.hostPlatform.system}.hyprcursor-phinger}/share/icons/theme_phinger-cursors-light";
         target = ".local/share/icons/phinger-cursors-light-hyprcursor";
       };
       "phinger-cursors-dark" = {
-        source = "${self.packages.${pkgs.system}.hyprcursor-phinger}/share/icons/theme_phinger-cursors-dark";
+        source = "${self.packages.${pkgs.stdenv.hostPlatform.system}.hyprcursor-phinger}/share/icons/theme_phinger-cursors-dark";
         target = ".local/share/icons/phinger-cursors-dark-hyprcursor";
       };
     };


### PR DESCRIPTION
### Changes

1. Replace pkgs.system with pkgs.stdenv.hostPlatform.system to avoid using the deprecated pkgs.system field in the flake.
2. Update inputs.